### PR TITLE
Adding modern TS-compatible typings annotation into the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dts-generator": "^1.6.3",
     "reflect-metadata": "^0.1.3"
   },
+  "typings": "target/src/core/di.d.ts",
   "typescript": {
     "definition": "target/ditsy.d.ts"
   }


### PR DESCRIPTION
I've added a link to proper typings file so that `ditsy` can be used like this in TypeScript code:

```
import {Injector, Injectable, Inject} from 'ditsy';
```
